### PR TITLE
fix(logging): fix empty links between test cases

### DIFF
--- a/lib/run/index.js
+++ b/lib/run/index.js
@@ -132,10 +132,15 @@ Runner.prototype.initFramework = function() {
   testProcess.stderr.setEncoding('utf8');
 
   testProcess.stdout.on('data', data => {
+    if (typeof data === 'string') {
+      data = data.replace(/\r?\n|\r$/, '');
+    }
     this.emit('data', data);
   });
-
   testProcess.stderr.on('data', data => {
+    if (typeof data === 'string') {
+      data = data.replace(/\r?\n|\r$/, '');
+    }
     this.emit('data', data);
   });
 


### PR DESCRIPTION
when mocha output to `stdout`, the `data` already has a new line, hence we should remove it before sending it to logger where it will add another new line.

| before | after |
| --- | --- |
| ![Screenshot 2021-02-09 at 8 25 39 PM](https://user-images.githubusercontent.com/1209810/107363993-d9f30600-6b15-11eb-966d-ce9749708bbd.png) | ![Screenshot 2021-02-09 at 8 24 41 PM](https://user-images.githubusercontent.com/1209810/107364021-e11a1400-6b15-11eb-8579-d47d0304b26a.png) |
