### PR TITLE
fix: directory参数问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage/
 .nyc_output/
 *.sw*
 *.un~
+.idea

--- a/bin/macaca-cli-run.js
+++ b/bin/macaca-cli-run.js
@@ -25,7 +25,7 @@ const options = {
 program
   .option('-f, --framework <s>', 'Set test framework (defaults: ' + options.framework + ')')
   .option('-p, --port <d>', 'Set port for server (defaults: ' + options.port + ')')
-  .option('-d, --directory <items>', 'Set directory for task runner (defaults: ' + options.directory + ')', value => value.split(','))
+  .option('-d, --directory <s>', 'Set directory for task runner (defaults: ' + options.directory + ')')
   .option('-o, --output [s]', 'Set output html file')
   .option('-r, --reporter <s>', 'Set reporter (default: Spec)')
   .option('-c, --colors <s>', 'Force enabling of colors (defaults: ' + options.colors + ')')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macaca-cli",
-  "version": "2.2.6",
+  "version": "2.3.0",
   "description": "Macaca command-line interface",
   "keywords": [
     "automation",


### PR DESCRIPTION
会造成glob表达式中的逗号被分割，破坏入参